### PR TITLE
feat: Add LLM selector to scenario generator UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,13 +7,14 @@ from flask import Flask, render_template, request, Response, jsonify
 from weasyprint import HTML
 from generator import generate_scenario
 from chat import run_chat_completion
-from llm_config import get_provider_config
+from llm_config import get_provider_config, llm_providers
 
 app = Flask(__name__)
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    model_names = list(llm_providers.keys())
+    return render_template('index.html', models=model_names)
 
 @app.route('/generate', methods=['POST'])
 def generate():
@@ -27,9 +28,10 @@ def generate():
         "core_idea": request.form.get('core_idea')
     }
     language = request.form.get('language')
+    model_name = request.form.get('llm_model')
 
     # Generate the scenario
-    markdown_output = generate_scenario(scenario_details, language=language)
+    markdown_output = generate_scenario(scenario_details, language=language, model_name=model_name)
 
     # Convert markdown to HTML for display
     html_output = markdown2.markdown(markdown_output, extras=["fenced-code-blocks", "tables"])

--- a/generator.py
+++ b/generator.py
@@ -1,15 +1,11 @@
-import os
 import re
 from dotenv import load_dotenv
-from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
+from chat import get_llm_instance # Re-use the instance creation logic
 
-# --- 1. Language Model (LLM) Configuration via Google Gemini API ---
+# --- Load Environment Variables ---
 load_dotenv()
-
-if "GOOGLE_API_KEY" not in os.environ:
-    raise ValueError("ERROR: The GOOGLE_API_KEY environment variable is not set.")
 
 def clean_llm_output(text: str) -> str:
     """
@@ -21,11 +17,18 @@ def clean_llm_output(text: str) -> str:
     cleaned_text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL)
     return cleaned_text.strip()
 
-def generate_scenario(scenario_details: dict, language: str = "English") -> str:
+def generate_scenario(scenario_details: dict, language: str = "English", model_name: str = "gemini-flash") -> str:
     """
-    Generates a complete RPG scenario from the provided details in the specified language.
+    Generates a complete RPG scenario from the provided details in the specified language,
+    using the selected language model.
     """
-    llm = ChatGoogleGenerativeAI(model="gemini-1.5-flash", temperature=0.8, convert_system_message_to_human=True)
+    # --- 1. Get the selected LLM instance ---
+    # Default to 'gemini-flash' if the model_name is not provided or invalid
+    try:
+        llm = get_llm_instance(model_name)
+    except (ValueError, KeyError):
+        llm = get_llm_instance("gemini-flash")
+
 
     # --- 2. Definition of Prompts for the Agents ---
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,13 @@
                 <option value="Greek">Greek</option>
             </select>
 
+            <label for="llm_model">Language Model (LLM)</label>
+            <select id="llm_model" name="llm_model">
+                {% for model in models %}
+                    <option value="{{ model }}" {% if model == 'gemini-flash' %}selected{% endif %}>{{ model }}</option>
+                {% endfor %}
+            </select>
+
             <label for="game_system">Game System</label>
             <input type="text" id="game_system" name="game_system" value="Cyberpunk with the Cypher System" required>
 


### PR DESCRIPTION
This commit introduces a dropdown menu on the scenario generator's main page, allowing users to select which configured LLM they want to use for generation.

Key changes:
- `app.py` is updated to pass the list of available LLM models to the `index.html` template. It also retrieves the user's selection from the form post.
- `templates/index.html` is modified to include a `<select>` dropdown, which is dynamically populated with the available models.
- `generator.py` is refactored to no longer use a hardcoded LLM. It now accepts a `model_name` and uses the `get_llm_instance` factory function to instantiate the correct model, making it fully dynamic.