### PR TITLE
fix: Improve error handling for LLM configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,13 +30,16 @@ def generate():
     language = request.form.get('language')
     model_name = request.form.get('llm_model')
 
-    # Generate the scenario
-    markdown_output = generate_scenario(scenario_details, language=language, model_name=model_name)
-
-    # Convert markdown to HTML for display
-    html_output = markdown2.markdown(markdown_output, extras=["fenced-code-blocks", "tables"])
-
-    return render_template('result.html', scenario_html=html_output, scenario_markdown=markdown_output)
+    try:
+        # Generate the scenario
+        markdown_output = generate_scenario(scenario_details, language=language, model_name=model_name)
+        # Convert markdown to HTML for display
+        html_output = markdown2.markdown(markdown_output, extras=["fenced-code-blocks", "tables"])
+        return render_template('result.html', scenario_html=html_output, scenario_markdown=markdown_output)
+    except ValueError as e:
+        # Display a user-friendly error message if configuration is missing (e.g., API key)
+        error_message = f"Failed to generate scenario. Configuration error for model '{model_name}': {e}"
+        return render_template('result.html', error=error_message)
 
 def slugify(text):
     """

--- a/generator.py
+++ b/generator.py
@@ -23,12 +23,11 @@ def generate_scenario(scenario_details: dict, language: str = "English", model_n
     using the selected language model.
     """
     # --- 1. Get the selected LLM instance ---
-    # Default to 'gemini-flash' if the model_name is not provided or invalid
-    try:
-        llm = get_llm_instance(model_name)
-    except (ValueError, KeyError):
-        llm = get_llm_instance("gemini-flash")
-
+    # If no model name is provided from the frontend, default to gemini-flash.
+    # The get_llm_instance function will raise a ValueError if the model is configured
+    # but the required API key is missing, which will be caught in app.py.
+    selected_model = model_name if model_name else "gemini-flash"
+    llm = get_llm_instance(selected_model)
 
     # --- 2. Definition of Prompts for the Agents ---
 

--- a/templates/result.html
+++ b/templates/result.html
@@ -20,16 +20,27 @@
     <div class="container">
         <h1>Your Scenario has been Generated!</h1>
 
-        <div class="toolbar">
-            <form action="/download_pdf" method="post" style="display: inline;">
-                <input type="hidden" name="markdown_content" value="{{ scenario_markdown }}">
-                <button type="submit">Download as PDF</button>
-            </form>
-        </div>
+        {% if error %}
+            <div class="error-box" style="background-color: #f8d7da; color: #721c24; padding: 1em; border: 1px solid #f5c6cb; border-radius: 8px;">
+                <h2>Error Generating Scenario</h2>
+                <p><strong>Please check your configuration.</strong></p>
+                <p>Details: {{ error }}</p>
+                <br>
+                <a href="/" style="text-decoration: none; padding: 0.8em 1.2em; background-color: #007BFF; color: white; border-radius: 4px;">Go Back and Correct</a>
+            </div>
+        {% else %}
+            <div class="toolbar">
+                <form action="/download_pdf" method="post" style="display: inline;">
+                    <input type="hidden" name="markdown_content" value="{{ scenario_markdown }}">
+                    <button type="submit">Download as PDF</button>
+                </form>
+                 <a href="/" style="display: inline-block; text-decoration: none; padding: 0.8em 1.2em; background-color: #007BFF; color: white; border-radius: 4px; font-size: 1em; margin-left: 10px;">Generate Another</a>
+            </div>
 
-        <div class="scenario-content">
-            {{ scenario_html|safe }}
-        </div>
+            <div class="scenario-content">
+                {{ scenario_html|safe }}
+            </div>
+        {% endif %}
     </div>
 </body>
 </html>


### PR DESCRIPTION
This commit fixes a bug where the application would silently fall back to the default LLM (Gemini) if the selected custom model had a configuration error (e.g., a missing API key).

The new behavior provides clear feedback to the user on the web page.

Key changes:
- `generator.py`: The `try...except` block that was hiding `ValueError` exceptions has been removed. The function now lets configuration errors propagate up.
- `app.py`: The `generate` route now wraps the call to `generate_scenario` in a `try...except ValueError` block. If an error is caught, it is passed to the results page.
- `templates/result.html`: The template is updated to display a prominent error box if an `error` variable is present, guiding the user to fix their configuration.