### PR TITLE
fix: Simplify and improve custom API key loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,18 @@ Pour une flexibilité maximale, notamment dans des environnements conteneurisés
     }
     ```
 
-2.  **Ajoutez les clés API** correspondantes dans votre fichier `.env`. Le nom de la variable doit correspondre à la valeur de `api_key_name`.
+2.  **Ajoutez la clé API** correspondante dans votre fichier `.env`.
     ```env
     # Clé pour le LLM personnalisé "mon-llm-local"
-    CUSTOM_OLLAMA_KEY="ollama"
+    AMOI_API_KEY="votre_cle_secrete"
     ```
 
-3.  **Spécifiez le chemin** vers votre fichier de configuration dans `.env`.
+3.  Dans votre fichier JSON, assurez-vous que la valeur de `"api_key_name"` est **exactement le même nom que la variable d'environnement**.
+    ```json
+     "api_key_name": "AMOI_API_KEY",
+    ```
+
+4.  **Spécifiez le chemin** vers votre fichier de configuration dans `.env`.
     ```env
     # Chemin vers le fichier JSON contenant les configurations des LLM personnalisés
     CUSTOM_LLM_CONFIG_PATH="/etc/secret/custom_llm.json"

--- a/chat.py
+++ b/chat.py
@@ -1,3 +1,4 @@
+import os
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from langchain_mistralai import ChatMistralAI
@@ -12,7 +13,10 @@ def get_llm_instance(model_name: str):
         model_name (str): The name of the model to initialize.
 
     Returns:
-        An instance of a LangChain chat model, or None if the provider is not found.
+        An instance of a LangChain chat model.
+
+    Raises:
+        ValueError: If the model is not configured or if the required API key is not set.
     """
     provider_config = get_provider_config(model_name)
     if not provider_config:
@@ -21,10 +25,15 @@ def get_llm_instance(model_name: str):
     service = provider_config["service"]
     config_model_name = provider_config["model_name"]
     api_key_name = provider_config.get("api_key_name")
-    api_key = api_keys.get(api_key_name)
 
-    if not api_key:
-        raise ValueError(f"API key '{api_key_name}' not found in environment variables.")
+    # Try to get the API key from the pre-defined dictionary,
+    # otherwise, get it directly from the environment variables.
+    api_key = api_keys.get(api_key_name)
+    if not api_key and api_key_name:
+        api_key = os.getenv(api_key_name)
+
+    if not api_key and api_key_name:
+        raise ValueError(f"API key for '{api_key_name}' not found. Please ensure the environment variable '{api_key_name}' is set in your .env file.")
 
     if service == "google":
         return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key)

--- a/llm_config.py
+++ b/llm_config.py
@@ -16,13 +16,7 @@ api_keys = {
     "openai": os.getenv("OPENAI_API_KEY"),
     "mistral": os.getenv("MISTRAL_API_KEY"),
     "custombot": os.getenv("CUSTOMBOT_API_KEY"),
-    # Add any other keys for custom models here, e.g.,
-    # "custom_llm_1_key": os.getenv("CUSTOM_LLM_1_KEY"),
 }
-# Dynamically load any other env vars starting with 'CUSTOM_'
-for key, value in os.environ.items():
-    if key.upper().startswith('CUSTOM_') and key.upper() not in api_keys:
-        api_keys[key.lower()] = value
 
 
 # --- LLM Provider Configuration ---


### PR DESCRIPTION
This commit refactors the mechanism for loading API keys for custom LLM providers to make it more intuitive and robust.

Previously, custom API keys required a specific prefix in their environment variable name (`CUSTOM_`) to be loaded, which was confusing. The new implementation simplifies this:

1.  The `api_key_name` field in the `custom_llm.json` configuration now directly corresponds to the name of the environment variable.
2.  The logic in `chat.py` first checks for pre-configured keys and then falls back to reading the specified environment variable directly with `os.getenv()`.
3.  The error message for a missing key has been improved to clearly state which environment variable needs to be set.
4.  The `README.md` has been updated to reflect this simpler and more powerful method.