### PR TITLE
feat: Add a network connectivity test endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,18 @@ Pour une flexibilité maximale, notamment dans des environnements conteneurisés
     # CUSTOM_LLM_CONFIG_PATH="custom_llm.json"
     ```
 L'application chargera automatiquement les modèles de ce fichier au démarrage. Vous pourrez alors les appeler via l'API en utilisant leur nom (ex: `"model": "mon-llm-local"`).
+
+---
+
+## Dépannage
+
+### Problèmes de Connexion avec un LLM Personnalisé
+
+Si vous rencontrez une `APIConnectionError` ou si vos appels vers un LLM personnalisé ne semblent pas fonctionner, utilisez le point de terminaison de test pour diagnostiquer le problème.
+
+Accédez à l'URL suivante dans votre navigateur :
+`http://localhost:8000/test-connection/VOTRE_NOM_DE_MODELE`
+
+Remplacez `VOTRE_NOM_DE_MODELE` par le nom de votre modèle personnalisé (ex: `mon-llm-local`).
+
+La réponse JSON vous indiquera si la connexion a réussi ou échoué, et vous donnera des détails sur l'erreur (par exemple, "Connection timed out" ou "Failed to establish a connection"). Cela vous aidera à déterminer s'il s'agit d'un problème de pare-feu, de DNS ou d'accessibilité de votre API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Markdown2
 beautifulsoup4
 langchain-openai
 langchain-mistralai
+requests


### PR DESCRIPTION
This commit adds a new debugging endpoint `/test-connection/<model_name>` to help users diagnose network issues when connecting to custom LLM APIs.

This feature was added to address a user's `openai.APIConnectionError`, allowing them to verify if the application server can reach their custom API endpoint.

Key changes:
- `app.py`: A new route `/test-connection/<model_name>` is added. It uses the `requests` library to perform a `HEAD` request to the configured endpoint and returns a detailed JSON response about the connection status.
- `requirements.txt`: The `requests` library is explicitly added as a dependency.
- `README.md`: A new "Troubleshooting" section is added to explain how to use the new endpoint.