### PR TITLE
feat: Add support for custom authentication headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Chaque fournisseur est un dictionnaire dans `llm_providers`. Voici les clés pri
 - `api_key_name`: La clé correspondante dans votre fichier `.env` (par exemple, `google`, `openai`).
 - `endpoint` (Optionnel): L'URL de base pour les API personnalisées compatibles avec OpenAI.
 - `system_prompt` (Optionnel): Un prompt système par défaut.
+- `headers` (Optionnel): Un dictionnaire pour spécifier des en-têtes HTTP personnalisés (par exemple, pour une authentification non standard).
 
 ### Ajouter des LLMs personnalisés (Méthode avancée)
 
@@ -129,8 +130,12 @@ Pour une flexibilité maximale, notamment dans des environnements conteneurisés
 
 3.  Dans votre fichier JSON, assurez-vous que la valeur de `"api_key_name"` est **exactement le même nom que la variable d'environnement** que vous venez de définir.
     ```json
-     "api_key_name": "CUSTOM_API_KEY_2"
+     "api_key_name": "CUSTOM_API_KEY_2",
+     "headers": {
+        "x-api-key": "{api_key}"
+     }
     ```
+    Le placeholder `{api_key}` sera automatiquement remplacé par la valeur de la variable d'environnement correspondante (`CUSTOM_API_KEY_2` dans cet exemple). Si votre API n'utilise pas l'en-tête `Authorization: Bearer`, c'est la méthode à utiliser.
 
 4.  **Spécifiez le chemin** vers votre fichier de configuration personnel dans `.env`.
     ```env


### PR DESCRIPTION
This commit introduces the ability to specify custom HTTP headers for LLM providers, enabling support for APIs that use non-standard authentication methods (e.g., using an `x-api-key` header instead of `Authorization: Bearer`).

This resolves the final issue preventing the user's custom API from working.

Key changes:
- `chat.py`: The `get_llm_instance` function now checks for a `headers` dictionary in a provider's configuration. If found, it constructs the specified headers, replacing an `{api_key}` placeholder with the real key, and passes them to the `ChatOpenAI` client.
- `app.py`: The `/test-connection` endpoint is updated to use the same custom header logic, ensuring it remains an accurate diagnostic tool.
- `README.md`: The documentation is updated to explain the new `headers` configuration option, providing a clear example for users.