### PR TITLE
feat: Add configurable timeout for LLM requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Chaque fournisseur est un dictionnaire dans `llm_providers`. Voici les clés pri
 - `endpoint` (Optionnel): L'URL de base pour les API personnalisées compatibles avec OpenAI.
 - `system_prompt` (Optionnel): Un prompt système par défaut.
 - `headers` (Optionnel): Un dictionnaire pour spécifier des en-têtes HTTP personnalisés (par exemple, pour une authentification non standard).
+- `timeout` (Optionnel): Le temps d'attente en secondes pour la réponse de l'API (par défaut 60).
 
 ### Ajouter des LLMs personnalisés (Méthode avancée)
 

--- a/app.py
+++ b/app.py
@@ -307,7 +307,8 @@ def test_connection(model_name):
     }
 
     try:
-        response = requests.post(full_url, headers=final_headers, json=payload, timeout=10)
+        timeout = provider_config.get("timeout", 60)
+        response = requests.post(full_url, headers=final_headers, json=payload, timeout=timeout)
 
         return jsonify({
             "status": "request_sent",

--- a/chat.py
+++ b/chat.py
@@ -58,15 +58,18 @@ def get_llm_instance(model_name: str):
     # The user is expected to handle the full auth in the custom `headers` field.
     final_api_key = None if custom_headers_config else api_key
 
+    # --- Timeout Configuration ---
+    timeout = provider_config.get("timeout", 60)
+
 
     if service == "google":
-        return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key)
+        return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key, client_options={"timeout": timeout})
 
     elif service == "openai":
-        return ChatOpenAI(model=config_model_name, api_key=final_api_key, extra_headers=extra_headers)
+        return ChatOpenAI(model=config_model_name, api_key=final_api_key, extra_headers=extra_headers, timeout=timeout)
 
     elif service == "mistral":
-        return ChatMistralAI(model=config_model_name, api_key=api_key)
+        return ChatMistralAI(model=config_model_name, api_key=api_key, timeout=timeout)
 
     elif service == "openai_compatible":
         endpoint = provider_config.get("endpoint")
@@ -76,7 +79,8 @@ def get_llm_instance(model_name: str):
             model=config_model_name,
             api_key=final_api_key,
             base_url=endpoint,
-            extra_headers=extra_headers
+            extra_headers=extra_headers,
+            timeout=timeout
         )
 
     else:

--- a/llm_config.py
+++ b/llm_config.py
@@ -29,18 +29,21 @@ llm_providers = {
         "model_name": "gemini-1.5-flash",
         "api_key_name": "google",
         "system_prompt": "You are a helpful assistant powered by Google Gemini.",
+        "timeout": 60,
     },
     "gpt-4": {
         "service": "openai",
         "model_name": "gpt-4",
         "api_key_name": "openai",
         "system_prompt": "You are a helpful assistant powered by OpenAI GPT-4.",
+        "timeout": 60,
     },
     "mistral-large": {
         "service": "mistral",
         "model_name": "mistral-large-latest",
         "api_key_name": "mistral",
         "system_prompt": "You are a helpful assistant powered by Mistral AI.",
+        "timeout": 60,
     },
 }
 


### PR DESCRIPTION
This commit introduces a new optional `timeout` parameter to the LLM provider configuration, allowing users to set a custom timeout for API requests.

This addresses the issue where the previous hardcoded timeout was too short for long-running LLM tasks.

Key changes:
- `llm_config.py`: The default configurations for public models now include a `timeout` of 60 seconds.
- `chat.py`: The `get_llm_instance` function now reads the `timeout` value from a provider's configuration (defaulting to 60 if not set) and passes it to the underlying LangChain client. This is supported for OpenAI, Mistral, and Google clients.
- `app.py`: The `/test-connection` endpoint is updated to use the configured timeout, ensuring it remains an accurate diagnostic tool.
- `README.md`: The documentation is updated to include the new `timeout` field in the configuration options.