### PR TITLE
fix: Correctly pass custom headers to ChatOpenAI client

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -66,7 +66,7 @@ def get_llm_instance(model_name: str):
         return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key, client_options={"timeout": timeout})
 
     elif service == "openai":
-        return ChatOpenAI(model=config_model_name, api_key=final_api_key, extra_headers=extra_headers, timeout=timeout)
+        return ChatOpenAI(model=config_model_name, api_key=final_api_key, client_kwargs={"extra_headers": extra_headers}, timeout=timeout)
 
     elif service == "mistral":
         return ChatMistralAI(model=config_model_name, api_key=api_key, timeout=timeout)
@@ -79,7 +79,7 @@ def get_llm_instance(model_name: str):
             model=config_model_name,
             api_key=final_api_key,
             base_url=endpoint,
-            extra_headers=extra_headers,
+            client_kwargs={"extra_headers": extra_headers},
             timeout=timeout
         )
 


### PR DESCRIPTION
This commit fixes a bug where custom headers for `openai_compatible` services were not being passed correctly to the underlying HTTP client.

The `extra_headers` dictionary was being passed as a direct parameter to the `ChatOpenAI` constructor, which resulted in a `UserWarning` and the headers not being sent.

The fix is to pass the dictionary via the `client_kwargs` parameter, as expected by the `langchain-openai` library.

- `chat.py`: The `ChatOpenAI` constructor calls are updated to use `client_kwargs={"extra_headers": ...}`.