### PR TITLE
fix: Use correct 'default_headers' param for OpenAI client

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -73,7 +73,7 @@ def get_llm_instance(model_name: str):
         http_client = OpenAI(
             base_url=endpoint,
             api_key=final_api_key,
-            extra_headers=extra_headers,
+            default_headers=extra_headers,
             timeout=timeout,
         ).chat.completions
 


### PR DESCRIPTION
This commit resolves the `TypeError: OpenAI.__init__() got an unexpected keyword argument 'extra_headers'`.

The previous attempts to pass custom headers via `extra_headers` or `client_kwargs` were incorrect for the `openai` library's constructor. After consulting the library's documentation, the correct parameter is `default_headers`.

This commit replaces the incorrect keyword with the correct one in `chat.py`, which should finally allow custom headers to be passed correctly to OpenAI-compatible endpoints.