### PR TITLE
feat: Implement non-streaming, interactive scenario generation

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -60,18 +60,11 @@ def get_llm_instance(model_name: str):
         timeout = 60
 
     if service == "google":
-        return ChatGoogleGenerativeAI(
-            model=config_model_name,
-            google_api_key=api_key,
-            client_options={"timeout": timeout},
-            stream=True
-        )
+        return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key, client_options={"timeout": timeout})
 
     elif service in ["openai", "openai_compatible"]:
         endpoint = provider_config.get("endpoint")
 
-        # The http_client setup for ChatOpenAI does not need to change for streaming.
-        # The `streaming=True` flag is passed to the ChatOpenAI constructor.
         http_client = OpenAI(
             base_url=endpoint,
             api_key=final_api_key,
@@ -81,17 +74,11 @@ def get_llm_instance(model_name: str):
 
         return ChatOpenAI(
             model=config_model_name,
-            client=http_client,
-            streaming=True
+            client=http_client
         )
 
     elif service == "mistral":
-        return ChatMistralAI(
-            model=config_model_name,
-            api_key=api_key,
-            timeout=timeout,
-            streaming=True
-        )
+        return ChatMistralAI(model=config_model_name, api_key=api_key, timeout=timeout)
 
     else:
         raise ValueError(f"Unsupported LLM service: {service}")

--- a/generator.py
+++ b/generator.py
@@ -222,13 +222,13 @@ def clean_llm_output(text: str) -> str:
 
 def generate_step(llm, prompt, variables):
     """
-    A generic function to run a generation step and stream the output.
+    A generic function to run a generation step using the non-streaming invoke() method.
+    It yields the entire result as a single chunk.
     """
     chain = prompt | llm | StrOutputParser()
-    response_stream = chain.stream(variables)
-    for chunk in response_stream:
-        cleaned_chunk = clean_llm_output(chunk)
-        yield cleaned_chunk
+    response = chain.invoke(variables)
+    cleaned_response = clean_llm_output(response)
+    yield cleaned_response
 
 # --- Modular Generation Functions ---
 


### PR DESCRIPTION
Refactors the entire application to support a multi-step, interactive scenario generation process, accommodating APIs that do not support streaming.

This addresses the user's core request for a more dynamic and controlled creation process, where each part of the scenario (synopsis, NPCs, locations, etc.) is generated via a separate, user-triggered request.

Key Changes:

1.  **Backend Refactoring (`generator.py`, `app.py`):**
    - The generation logic in `generator.py` now uses the blocking `invoke()` method instead of `stream()`, as the target API does not support streaming. Each step's content is generated completely before being sent to the client.
    - The `/generate` endpoint in `app.py` has been refactored to act as a controller, calling the appropriate non-streaming generation function based on a `step` parameter from the client.
    - The LLM client configuration in `chat.py` has been corrected to not request streaming.

2.  **Frontend Overhaul (`templates/index.html`):**
    - The JavaScript now manages a state machine for the step-by-step flow, sending a new request for each step with the full context of previously generated parts.
    - The UI has been updated to guide the user, with the "Suivant" button's label changing to reflect the next action.
    - The page layout is a 40/60 two-column split as per the user's request.