### PR TITLE
fix: Add missing json5 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ beautifulsoup4
 langchain-openai
 langchain-mistralai
 requests
+json5


### PR DESCRIPTION
The application was crashing on startup with a `ModuleNotFoundError` because the `json5` package was imported but not listed in the `requirements.txt` file.

This commit adds `json5` to the list of dependencies to ensure it is installed when setting up the environment, resolving the startup error.