### PR TITLE
fix: Add missing json5 dependency and correct prompt template

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -108,17 +108,8 @@ Output Requirements:
 - The final output must be in {language}.
 
 Example Outputs:
-Valid:
-{
-    "npcs": ["The Stormcaller", "Old Man Harkin", "The Faceless Choir"],
-    "locations": ["The Weeping Spire", "Harkin's Boat", "The Bone Marshes"]
-}
-
-Empty case:
-{
-    "npcs": [],
-    "locations": ["The Abandoned Lighthouse"]
-}
+- A valid JSON output looks like this: `{"npcs": ["The Stormcaller", "Old Man Harkin"], "locations": ["The Weeping Spire", "The Bone Marshes"]}`
+- If no NPCs are found, the JSON should look like this: `{"npcs": [], "locations": ["The Abandoned Lighthouse"]}`
 
 Strict Prohibitions:
 - NO descriptions or attributes


### PR DESCRIPTION
This commit addresses two separate issues:

1.  A `ModuleNotFoundError` for the `json5` package. The application imports `json5` but it was not declared in `requirements.txt`. This change adds it to the dependencies to resolve the startup error.

2.  An `InvalidPromptInput` error from LangChain. A multi-line JSON example in the prompt for `agent_1_list_items` in `generator.py` was being misinterpreted as a template variable. The prompt has been rewritten to use a clearer, single-line format for the examples, which prevents the parsing error.