### PR TITLE
feat: Implement streaming for chat completions

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -83,16 +83,18 @@ def get_llm_instance(model_name: str):
     else:
         raise ValueError(f"Unsupported LLM service: {service}")
 
-def run_chat_completion(model_name: str, messages: list):
+def run_chat_completion(model_name: str, messages: list, stream: bool = False):
     """
     Runs a chat completion with the specified model and messages.
 
     Args:
         model_name (str): The name of the model to use.
         messages (list): A list of message dictionaries, e.g., [{"role": "user", "content": "Hello"}].
+        stream (bool): If True, streams the response.
 
     Returns:
-        The content of the AI's response message.
+        If stream is False, a string with the full response.
+        If stream is True, a generator that yields response chunks.
     """
     llm = get_llm_instance(model_name)
 
@@ -111,5 +113,8 @@ def run_chat_completion(model_name: str, messages: list):
             chat_messages.append(SystemMessage(content=msg["content"]))
         # LangChain automatically handles assistant messages in the history
 
-    response = llm.invoke(chat_messages)
-    return response.content
+    if stream:
+        return (chunk.content for chunk in llm.stream(chat_messages))
+    else:
+        response = llm.invoke(chat_messages)
+        return response.content


### PR DESCRIPTION
Adds streaming support to the `/v1/chat/completions` endpoint to prevent timeouts on long-running requests from large models.

- The `run_chat_completion` function in `chat.py` now accepts a `stream` parameter and uses `llm.stream()` to yield response chunks.
- The `/v1/chat/completions` endpoint in `app.py` now checks for a `stream: true` parameter in the request body.
- If streaming is requested, the endpoint returns a `text/event-stream` response, sending data in OpenAI-compatible Server-Sent Events (SSE) format.
- This keeps the connection alive and resolves the "context canceled" errors seen in `cloudflared`.