### PR TITLE
feat(debug): Add temporary debugging code for agent_2

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -283,7 +283,19 @@ def agent_2_detail_npc(llm, language, scenario_details, context):
     """
     synopsis = scenario_details
     npc_name = context.get('item_name', '') # The item to detail is passed in context
-    return invoke_llm(llm, prompt_agent_2, {"synopsis": synopsis, "npc_name": npc_name, "language": language})
+
+    # --- DEBUGGING STEP ---
+    # Instead of calling the LLM, return the variables that would be used.
+    debug_info = {
+        "debug_step": "agent_2_detail_npc",
+        "prompt_used": "prompt_agent_2",
+        "variables_passed": {
+            "synopsis": synopsis,
+            "npc_name": npc_name,
+            "language": language
+        }
+    }
+    return json.dumps(debug_info, indent=2)
 
 def agent_3_detail_location(llm, language, scenario_details, context):
     """


### PR DESCRIPTION
This commit introduces a non-functional change to the `agent_2_detail_npc` function for debugging purposes. Instead of calling the language model, the function now returns a JSON object containing the name of the prompt and the variables that would have been passed to it.

This will allow for inspection of the runtime state to diagnose a persistent KeyError.

This commit should be reverted before final submission.