### PR TITLE
Fix: Ensure correct LLM selection and fix Gemini timeout

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -60,7 +60,7 @@ def get_llm_instance(model_name: str):
         timeout = 60
 
     if service == "google":
-        return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key, client_options={"timeout": timeout})
+        return ChatGoogleGenerativeAI(model=config_model_name, google_api_key=api_key, timeout=timeout)
 
     elif service in ["openai", "openai_compatible"]:
         endpoint = provider_config.get("endpoint")

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,7 +59,7 @@
                     </select>
 
                     <label for="llm_model">Language Model (LLM)</label>
-                    <select id="llm_model" name="llm_model">
+                    <select id="llm_model" name="model">
                         {% for model in models %}
                             <option value="{{ model }}" {% if model == 'gemini-flash' %}selected{% endif %}>{{ model }}</option>
                         {% endfor %}


### PR DESCRIPTION
This commit addresses two issues:
1. The user's LLM selection from the frontend was being ignored because the `name` attribute in the HTML form (`llm_model`) did not match the key expected by the backend (`model`).
2. The application would crash when using the Gemini model due to an incorrect parameter being passed for the timeout.

The following changes have been made:
- In `templates/index.html`: The `name` attribute of the model selection dropdown has been changed to `model`.
- In `chat.py`: The `ChatGoogleGenerativeAI` instantiation has been corrected to pass `timeout` as a direct keyword argument.