### PR TITLE
Fix(generator): Correct indentation of _run_task body

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -68,17 +68,17 @@ def generate_scenario(llm, theme, motif, contraintes, accroche_selectionnee):
     def _run_task(agent_name, task_description, **kwargs):
         agent = agents[agent_name]
 
-    # Dynamically build the context string with placeholders for each kwarg.
-    # This creates a string like:
-    # **Theme Fourni(e)**:
-    # {theme}
-    #
-    # **Motif Fourni(e)**:
-    # {motif}
-    context_inputs = "\n\n".join([f"**{key.capitalize()} Fourni(e)**:\n{{{key}}}" for key in kwargs])
+        # Dynamically build the context string with placeholders for each kwarg.
+        # This creates a string like:
+        # **Theme Fourni(e)**:
+        # {theme}
+        #
+        # **Motif Fourni(e)**:
+        # {motif}
+        context_inputs = "\n\n".join([f"**{key.capitalize()} Fourni(e)**:\n{{{key}}}" for key in kwargs])
 
-    # Construct the full prompt template.
-    prompt_template = f"""
+        # Construct the full prompt template.
+        prompt_template = f"""
 **Role**: {agent['role']}
 **Goal**: {agent['goal']}
 **Backstory**: {agent['backstory']}
@@ -86,14 +86,14 @@ def generate_scenario(llm, theme, motif, contraintes, accroche_selectionnee):
 **Contexte de la Tâche**:
 {context_inputs}
 
-    **Tâche à réaliser**:
+        **Tâche à réaliser**:
 {task_description}
 """
-    # Create the chain with the dynamic prompt template.
-    chain = _create_chain(llm, prompt_template)
+        # Create the chain with the dynamic prompt template.
+        chain = _create_chain(llm, prompt_template)
 
-    # Invoke the chain, passing the kwargs dictionary for the template to populate its placeholders.
-    return chain.invoke(kwargs)
+        # Invoke the chain, passing the kwargs dictionary for the template to populate its placeholders.
+        return chain.invoke(kwargs)
 
     # Task 1: Generate initial ideas
     task_ideation_output = _run_task(


### PR DESCRIPTION
A previous commit introduced an indentation error that placed the logic of the `_run_task` function outside of the function itself. This resulted in a `NameError` because the `kwargs` variable was not defined in the scope where it was being accessed.

This commit corrects the indentation, moving the function body to the correct scope and resolving the `NameError`.