### PR TITLE
Fix: Correctly parse and display initial scenario hooks

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -17,114 +17,50 @@ def generate_scenario(llm, theme, motif, contraintes, accroche_selectionnee):
     agents = {
         "ideateur": {
             "role": "Idéateur de Concept",
-            "goal": (
-                "Imaginer 2 à 3 accroches narratives originales autour du sujet défini par l’utilisateur. "
-                "Chaque accroche doit être une situation de départ intrigante ou prometteuse, adaptée au thème choisi, "
-                "au motif narratif (action, aventure, mystère…) et aux contraintes données. "
-                "Ces accroches ne sont pas des histoires complètes, mais des points de départ percutants."
-            ),
-            "backstory": (
-                "Tu es un maître conteur visionnaire, spécialisé dans l’art de déclencher l’imagination des joueurs. "
-                "Ton talent repose sur ta capacité à créer des situations inattendues qui suscitent immédiatement "
-                "l’envie d’explorer, de résoudre ou de se lancer à l’aventure."
-            ),
+            "goal": "Proposer des accroches et des situations de départ originales et adaptées au thème, au motif narratif et aux contraintes définies par l’utilisateur. Générer 2 à 3 accroches fortes qui posent une base intrigante et jouable pour un scénario de jeu de rôle.",
+            "backstory": "Tu es un maître conteur visionnaire, spécialisé dans l’art de lancer des aventures de manière mémorable. Tu excelles dans la création de situations intrigantes, de dangers et de retournements de situation qui suscitent immédiatement la curiosité. Tu sais adapter tes idées au genre (SF, fantasy, horreur, contemporain, etc.), au motif narratif voulu (action, aventure, mystère, tragédie, etc.) et aux contraintes spécifiques (par ex. : pas de magie, recadrage urbain, réaliste, low-tech, etc.). Ton rôle est de poser les premières pierres d’une grande histoire, en respectant et sublimant les contraintes données.",
         },
         "stratege": {
             "role": "Stratège Antagoniste",
-            "goal": (
-                "Définir la figure de l’adversité centrale de l’histoire à partir de l’accroche retenue. "
-                "Créer un antagoniste clair (individu, organisation, créature, force), en précisant objectifs, motivations, "
-                "méthodes, ressources, forces et faiblesses. "
-                "Il doit représenter un moteur narratif crédible et stimulant pour les joueurs."
-            ),
-            "backstory": (
-                "Tu es un dramaturge spécialisé dans la conception de conflits puissants. "
-                "Pour toi, l’antagoniste est le cœur qui fait battre l’histoire en donnant du poids aux actions des joueurs. "
-                "Tu crées des ennemis marquants, profonds et imparfaits."
-            ),
+            "goal": "Concevoir l’adversité centrale du scénario en créant un antagoniste fort, cohérent et adapté à l’histoire. À partir de l’accroche choisie, du thème et du motif narratif, tu dois définir un opposant qui sera le moteur du conflit. L’antagoniste doit être crédible, marquant et offrir des opportunités dramatiques riches.",
+            "backstory": "Tu es un maître tacticien et dramaturge spécialisé dans la création d’antagonistes mémorables. Tu comprends que sans un défi bien conçu, une histoire manque de puissance dramatique. Ton travail est de forger une figure d’adversité (individu, faction, entité, force supérieure) qui ne soit pas seulement un obstacle, mais aussi un reflet des thèmes de l’histoire. Tu excelles à donner à tes créations une profondeur psychologique (objectifs, motivations positives et négatives, méthodes, personnalité) tout en leur offrant des supports narratifs (alliés, serviteurs, organisation, ressources).",
         },
         "contextualisateur": {
             "role": "Architecte de Contexte Narratif",
-            "goal": (
-                "Établir un cadre immersif et cohérent pour l’histoire en fonction de l’accroche et de l’antagoniste. "
-                "Préciser le décor principal, les forces sociales/politiques/culturelles en jeu, l’ambiance qui imprègne l’univers "
-                "et la raison pour laquelle les événements se déclenchent à ce moment précis."
-            ),
-            "backstory": (
-                "Ancien game designer de JDR, tu es expert en conception de mondes ancrés dans un contexte riche. "
-                "Tu refuses les décors génériques et privilégies les cadres où chaque détail sert l’aventure et justifie l’action."
-            ),
+            "goal": "Créer un cadre immersif et jouable pour l’histoire.",
+            "backstory": "Ancien game designer pour des JDR comme *Cyberpunk Red* et *Vaesen*, tu as appris à créer des mondes où chaque détail sert l’aventure. Tu détestes les mondes 'génériques' et adores les contraste.",
         },
         "dramaturge": {
             "role": "Dramaturge",
-            "goal": (
-                "Transformer les éléments initiaux (accroche, antagoniste, contexte) en un synopsis structuré et jouable. "
-                "Définir un début clair, un milieu engageant, et une fin possible, en construisant une courbe dramatique cohérente."
-            ),
-            "backstory": (
-                "Tu es un scénariste chevronné qui comprend comment bâtir des récits captivants. "
-                "Tu structures les histoires de manière à maintenir tension, enjeux, et émotions."
-            ),
+            "goal": "Construire la structure globale de l'histoire. Élaborer le synopsis avec un début, un milieu et une fin clairs, en résumant les étapes principales du scénario et en définissant le schéma de tension.",
+            "backstory": "Tu es un scénariste chevronné, spécialisé dans la construction d'arcs narratifs puissants. Tu sais comment structurer une histoire pour maximiser l'impact émotionnel et maintenir l'intérêt des joueurs.",
         },
         "metteur_en_scene": {
             "role": "Metteur en Scène",
-            "goal": (
-                "Découper le synopsis en une séquence claire de scènes ou chapitres jouables. "
-                "Pour chaque scène, indiquer son objectif narratif, les obstacles rencontrés et l’ambiance dominante. "
-                "Construire la montée en tension jusqu’au climax."
-            ),
-            "backstory": (
-                "Tu es un réalisateur narratif qui pense en séquences et en dynamiques de jeu. "
-                "Tu traduis le récit en étapes concrètes et immersives prêtes à être jouées à la table."
-            ),
+            "goal": "Transformer le synopsis en une liste claire de scènes jouables. Découper le scénario en chapitres ou scènes, en donnant pour chaque scène un objectif narratif, des obstacles et une ambiance.",
+            "backstory": "Tu es un réalisateur narratif, pensant en séquences et en moments de jeu. Ton talent est de transformer une histoire en une série d'étapes concrètes et passionnantes pour les joueurs et le maître de jeu.",
         },
         "specialiste_scene": {
             "role": "Spécialiste de Scène",
-            "goal": (
-                "Développer une scène précise du squelette narratif en une situation prête à jouer. "
-                "Décrire son ouverture, ses étapes détaillés avec les obstacles associées, les PNJ impliqués et les actions possibles pour les PJ. "
-                "Apporter une ambiance forte et sensorielle."
-            ),
-            "backstory": (
-                "Tu es un concepteur de situations de jeu immersives. "
-                "Ton rôle est de donner vie à une scène pour que le Meneur de Jeu puisse la proposer directement aux joueurs."
-            ),
+            "goal": "Développer en détail une scène à partir du squelette fourni par le Metteur en Scène. Décrire la mise en situation, les obstacles, les pistes d'action et l'ambiance.",
+            "backstory": "Tu es un concepteur de situations de jeu immersives. Tu prends une idée de scène et tu la transformes en une expérience vivante et détaillée, prête à être jouée.",
         },
         "architecte_pnj": {
             "role": "Architecte des PNJ",
-            "goal": (
-                "Concevoir les fiches des PNJ majeurs du scénario (alliés, antagonistes secondaires, neutres). "
-                "Donner identité, personnalité, motivations, apparence, forces et faiblesses pour qu’ils soient mémorables et utiles."
-            ),
-            "backstory": (
-                "Tu es un expert en psychologie et en caractérisation narrative. "
-                "Tu sais créer des personnages qui enrichissent l’histoire et rendent l’univers crédible et vivant."
-            ),
+            "goal": "Dresser les fiches de PNJ (Personnages Non-Joueurs) majeurs, qu'ils soient alliés, neutres ou antagonistes. Donner à chacun une identité, une personnalité, des motivations et une apparence.",
+            "backstory": "Tu es un expert en psychologie et en création de personnages. Tu sais que des PNJ mémorables sont la clé d'un monde vivant. Tu crées des individus crédibles et utiles à l'histoire.",
         },
         "architecte_lieux": {
             "role": "Architecte des Lieux",
-            "goal": (
-                "Décrire les lieux centraux du scénario avec une approche sensorielle et narrative. "
-                "Préciser leur ambiance, leur rôle dramatique et les défis ou opportunités liés au décor."
-            ),
-            "backstory": (
-                "Tu es un urbaniste de l’imaginaire, un architecte narratif qui conçoit des lieux jouables et mémorables. "
-                "Chaque décor que tu proposes est pensé pour être utilisé en jeu."
-            ),
+            "goal": "Détailler les lieux importants du scénario. Donner une description sensorielle (visuelle, sonore, ambiance), expliquer leur fonction narrative et proposer des obstacles ou opportunités liés au décor.",
+            "backstory": "Tu es un urbaniste de l'imaginaire et un peintre d'ambiances. Tu conçois des lieux qui ne sont pas de simples décors, mais des acteurs à part entière de l'histoire, riches en potentiel narratif.",
         },
         "verificateur": {
             "role": "Vérificateur de Cohérence Narrative",
-            "goal": (
-                "Relire et analyser les productions des autres agents pour garantir logique, cohérence et respect des contraintes utilisateur. "
-                "Signaler les incohérences et proposer des corrections simples sans réécrire les textes complets."
-            ),
-            "backstory": (
-                "Tu es un contrôleur qualité narratif au regard critique. "
-                "Ton rôle est de repérer les failles et de sécuriser la solidité du scénario avant les étapes suivantes."
-            ),
+            "goal": "Assurer la logique, la cohérence et la cohésion globale du scénario à travers les différentes étapes de sa création. Tu interviens pour valider la qualité et la pertinence des productions des autres agents.",
+            "backstory": "Tu es un contrôleur qualité narratif avec un œil de lynx pour les détails. Rien ne t'échappe : les failles dans l'intrigue, les motivations de personnages incohérentes, ou les ruptures de ton. Ton rôle est de garantir que le produit final soit un tout harmonieux et crédible.",
         },
     }
-
 
     def _run_task(agent_name, task_description, **kwargs):
         agent = agents[agent_name]
@@ -149,12 +85,17 @@ def generate_scenario(llm, theme, motif, contraintes, accroche_selectionnee):
         "ideateur",
         "Basé sur le thème, le motif et les contraintes fournis par l'utilisateur, "
         "génère 2 à 3 accroches de scénario distinctes et percutantes. "
-        "Chaque accroche doit être un court paragraphe intrigant.",
+        "Chaque accroche doit être un court paragraphe intrigant. Commence directement par la première accroche, sans phrase d'introduction.",
         theme=theme, motif=motif, contraintes=contraintes
     )
-    # For now, we will just use the first generated hook.
-    accroche_selectionnee = task_ideation_output.split('\n\n')[0]
-    yield f"<h2>Accroche Sélectionnée</h2>{markdown2.markdown(accroche_selectionnee, extras=markdown_options)}"
+    # Yield all the generated hooks for the user to see.
+    yield f"<h2>Accroches Initiales</h2>{markdown2.markdown(task_ideation_output, extras=markdown_options)}"
+
+    # Parse the output to select the first hook for the next agent.
+    # We split by double newline, filter out potential empty strings.
+    hooks = [hook.strip() for hook in task_ideation_output.split('\n\n') if hook.strip()]
+    # Select the first hook. If parsing fails, fall back to the full text.
+    accroche_selectionnee = hooks[0] if hooks else task_ideation_output
 
     # Task 2: Create the Antagonist
     task_antagoniste_output = _run_task(


### PR DESCRIPTION
This commit fixes a bug in the scenario generation stream where the initial hooks from the 'ideateur' agent were not being handled correctly.

The previous implementation would only select the introductory sentence from the agent's output, causing the next agent in the chain to fail due to missing input.

The fix includes:
- Updating the 'ideateur' agent's prompt to be more direct and avoid introductions.
- Yielding the full output of the 'ideateur' agent so that the user can see all the generated hooks.
- Improving the parsing logic to more reliably select the first valid hook from the output to be passed to subsequent agents.