### PR TITLE
Refactor: Remove input summary and add language control

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,6 +81,7 @@ def generate():
 
     # --- Dynamic LLM Initialization ---
     selected_model = data.get('model', 'gemini-flash')
+    language = data.get('language', 'French') # Default to French
     try:
         llm = get_llm_instance(selected_model)
     except Exception as e:
@@ -93,7 +94,7 @@ def generate():
         try:
             # Pass the entire data payload from the form to the generator.
             # The generator function is now responsible for handling the inputs.
-            for html_brick in generate_scenario(llm=llm, inputs=data):
+            for html_brick in generate_scenario(llm=llm, inputs=data, language=language):
                 yield html_brick
         except Exception as e:
             app.logger.error(f"An error occurred during scenario generation: {e}")


### PR DESCRIPTION
- Removed the initial display of raw user inputs ("Récapitulatif de vos choix") from the generated output.
- Added a language parameter to the generation process to explicitly define the output language for each task.
- The language is now passed down to the LLM prompt with a final instruction to ensure the response is in the requested language.