### PR TITLE
fix: Improve PDF layout and prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,8 +202,14 @@ def download_pdf():
                     font-size: 24pt;
                     /* Set a string variable with the content of the h2 for the footer */
                     string-set: current_section content();
+                    page-break-after: avoid;
                 }}
-                h3 {{ font-size: 18pt; border-bottom: 1px solid #eeeeee; padding-bottom: 5px; }}
+                h3 {{
+                    font-size: 18pt;
+                    border-bottom: 1px solid #eeeeee;
+                    padding-bottom: 5px;
+                    page-break-after: avoid;
+                }}
                 pre {{ background-color: #f5f5f5; padding: 1em; border-radius: 4px; white-space: pre-wrap; word-wrap: break-word; font-family: 'Courier New', Courier, monospace; }}
                 table {{ border-collapse: collapse; width: 100%; margin-top: 1em;}}
                 th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}

--- a/generator.py
+++ b/generator.py
@@ -163,7 +163,7 @@ def generate_scenario(llm, inputs, language="French"):
     # Task 7: Detail all scenes
     task_detail_scenes_output = _run_task(
         "specialiste_scene",
-        "Pour CHAQUE scène listée dans le découpage, écris une description détaillée (objectif, obstacles, ambiance, issues possibles).",
+        "Pour CHAQUE scène listée dans le découpage, écris une description détaillée (objectif, obstacles, ambiance, issues possibles). Ne crée pas de titre global et ne fais pas de phrase d'introduction. Commence directement par la description de la première scène.",
         language,
         decoupage_scenes=task_decoupage_scenes_output
     )
@@ -171,7 +171,7 @@ def generate_scenario(llm, inputs, language="French"):
     # Task 8: Create NPCs
     task_architecte_pnj_output = _run_task(
         "architecte_pnj",
-        "En te basant sur le synopsis et les scènes détaillées, identifie 3 à 5 PNJ majeurs et crée une fiche descriptive pour chacun.",
+        "En te basant sur le synopsis et les scènes détaillées, identifie 3 à 5 PNJ majeurs et crée une fiche descriptive pour chacun. Ne crée pas de titre global et ne fais pas de phrase d'introduction. Commence directement par la description du premier PNJ.",
         language,
         synopsis=task_synopsis_output,
         scenes_detaillees=task_detail_scenes_output
@@ -180,7 +180,7 @@ def generate_scenario(llm, inputs, language="French"):
     # Task 9: Create Locations
     task_architecte_lieux_output = _run_task(
         "architecte_lieux",
-        "En te basant sur le synopsis et les scènes détaillées, identifie 3 à 5 lieux importants et écris une description détaillée pour chacun.",
+        "En te basant sur le synopsis et les scènes détaillées, identifie 3 à 5 lieux importants et écris une description détaillée pour chacun. Ne crée pas de titre global et ne fais pas de phrase d'introduction. Commence directement par la description du premier lieu.",
         language,
         synopsis=task_synopsis_output,
         scenes_detaillees=task_detail_scenes_output


### PR DESCRIPTION
This commit addresses several layout issues in the PDF generation and refines the agent prompts to prevent duplicate content.

The following changes have been made:
- **CSS Page Breaks**: Added `page-break-after: avoid;` to h2 and h3 styles in `app.py`. This prevents section titles from being orphaned at the bottom of a page, ensuring they stay with their content.
- **Refined Agent Prompts**: Updated the prompts in `generator.py` for content-generating agents (`specialiste_scene`, `architecte_pnj`, `architecte_lieux`). They are now explicitly instructed not to generate their own titles or introductory phrases, which resolves the duplicate title issue.

These changes fix the layout bugs reported by the user and improve the overall quality and consistency of the generated PDF document.