### PR TITLE
Fix PDF generation due to NameError and indentation

### DIFF
--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -73,11 +73,10 @@ def create_pdf(html_content, template_path):
                 break
             section_html += str(sibling)
     
-    # Add the heading and its content to the dictionary
-    # You can now give a class to both h2 and h3 if needed for styling
-    heading['class'] = 'new-page' # Or create a specific class
-    # sections_content[section_slug] = str(heading) + section_html
-    sections_content[section_slug] = f'<h2 class="new-page">{h2.get_text()}</h2>' + section_html
+        # Add the heading and its content to the dictionary
+        # You can now give a class to both h2 and h3 if needed for styling
+        heading['class'] = 'new-page' # Or create a specific class
+        sections_content[section_slug] = str(heading) + section_html
 
 
     # 5. Render the final PDF using the Jinja2 template


### PR DESCRIPTION
The PDF generation was failing with a `NameError: name 'h2' is not defined` due to a faulty modification.

This change corrects the error by:
1. Fixing a bug where a loop that processes headings was de-dented, causing it to only process the last heading and leading to broken links in the table of contents.
2. Replacing a hardcoded `h2` variable with the correct `heading` loop variable.

This ensures all sections are processed correctly and included in the final PDF with working TOC links.