### PR TITLE
feat: Implement LLM-based dynamic font selection for PDFs

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,16 +82,13 @@ def download_pdf():
     Handles the PDF download request by calling the pdf_generator module.
     """
     html_content = request.form.get('html_content')
+    theme_tone = request.form.get('theme_tone', 'default') # Get theme, with a default
     if not html_content:
         return "Error: Content not found.", 400
 
     try:
-        # The create_pdf function now handles everything:
-        # - HTML parsing and cleaning
-        # - TOC generation
-        # - Rendering the final HTML from a template
-        # - Generating the PDF bytes
-        pdf_bytes = create_pdf(html_content, PDF_TEMPLATE_PATH)
+        # The create_pdf function now handles everything, including font selection
+        pdf_bytes = create_pdf(html_content, PDF_TEMPLATE_PATH, theme_tone)
 
         return Response(
             pdf_bytes,

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,6 +96,7 @@
                     <div id="result-html"></div>
                     <form action="/download_pdf" method="post" id="pdf-form" style="display: none; margin-top: 1em;">
                         <input type="hidden" name="html_content" id="html_content">
+                        <input type="hidden" name="theme_tone" id="theme_tone_hidden">
                         <button type="submit">Download as PDF</button>
                     </form>
                 </div>
@@ -154,6 +155,12 @@
 
                 // Generation is complete
                 htmlContentInput.value = resultHtml.innerHTML;
+
+                // Pass the theme to the PDF form
+                const themeToneInput = document.getElementById('theme_tone');
+                const hiddenThemeToneInput = document.getElementById('theme_tone_hidden');
+                hiddenThemeToneInput.value = themeToneInput.value;
+
                 pdfForm.style.display = 'block';
                 submitButton.textContent = 'Génération Terminée';
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -3,13 +3,24 @@
 <head>
     <title>{{ title }}</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Roboto:wght@400;700&display=swap');
-        @import url('https://fonts.googleapis.com/css2?family=Federo&family=Macondo&family=Macondo+Swash+Caps&display=swap');
-        @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400..900&display=swap');
+        /* --- Dynamic Font Loading --- */
+        /* The 'fonts' object is passed from the Python PDF generator */
+        {% if fonts and fonts.google_fonts_url %}
+        @import url('{{ fonts.google_fonts_url }}');
+        {% endif %}
 
-        /* General Body and Font Styles */
-        body { font-family: 'Roboto', serif; line-height: 1.6; color: #333; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Orbitron', sans-serif; font-weight: 700; }
+        /* --- General Body and Font Styles --- */
+        /* Fallback fonts are provided in case the Google Font fails to load */
+        body {
+            font-family: '{{ fonts.text_font | default('Roboto') }}', serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            font-family: '{{ fonts.title_font | default('Roboto') }}', sans-serif;
+            font-weight: 700;
+        }
+
         h2 {
             border-bottom: 2px solid #cccccc;
             padding-bottom: 10px;


### PR DESCRIPTION
This commit introduces a new feature to dynamically select Google Fonts for the generated PDF based on the user-provided theme.

An LLM is prompted with a catalog of pre-selected fonts to choose the most appropriate title and text fonts.

The PDF template is updated to use these dynamic fonts, with fallbacks in case of errors. The theme is passed from the frontend to the backend via a hidden form field.

This also cleans up old hardcoded font imports from the template.