### PR TITLE
fix(pdf): Correctly include h3 tags in PDF sections

### DIFF
--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -159,7 +159,7 @@ def create_pdf(html_content, template_path, theme_tone="Default"):
         section_slug = slugify(section_title)
         section_html = ''
         for sibling in heading.find_next_siblings():
-            if sibling.name in ['h2', 'h3']:
+            if sibling.name == 'h2':
                 break
             section_html += str(sibling)
 


### PR DESCRIPTION
The PDF generation process was failing to create anchors for h3 tags because the content parsing logic incorrectly treated h3 tags as section separators.

This change modifies the loop condition to only consider h2 tags as section breaks, ensuring that h3 tags and their content are properly included. This resolves the "No anchor for internal URI reference" error and ensures all content appears in the generated PDF.